### PR TITLE
fix: socket=fallback-x11 -> socket=x11

### DIFF
--- a/io.github.gitahead.GitAhead.json
+++ b/io.github.gitahead.GitAhead.json
@@ -7,7 +7,7 @@
   "separate-locales": false,
   "finish-args": [
     "--share=ipc",
-    "--socket=fallback-x11",
+    "--socket=x11",
     "--socket=wayland",
     "--device=dri",
     /*for git repos that require ssh keys*/


### PR DESCRIPTION
Doesn't start on Wayland with `socket=fallback-x11`.

```
qt.qpa.plugin: Could not find the Qt platform plugin "wayland" in ""
qt.qpa.xcb: could not connect to display 
qt.qpa.plugin: Could not load the Qt platform plugin "xcb" in "" even though it was found.
This application failed to start because no Qt platform plugin could be initialized. Reinstalling the application may fix this problem.

Available platform plugins are: xcb.
```