### PR TITLE
Fix name

### DIFF
--- a/io.github.gitahead.GitAhead.metainfo.xml
+++ b/io.github.gitahead.GitAhead.metainfo.xml
@@ -2,7 +2,7 @@
 <component type="desktop-application">
   <id>io.github.gitahead.GitAhead</id>
   
-  <name>Gitahead</name>
+  <name>GitAhead</name>
   <summary>Understand your Git history!</summary>
   
   <metadata_license>CC0-1.0</metadata_license>


### PR DESCRIPTION
Software centers show "Gitahead" and not "GitAhead".

![image](https://user-images.githubusercontent.com/50847364/116438319-51cef380-a81c-11eb-912e-9868a72be171.png)
